### PR TITLE
ci: add github release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Release the library
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Release library
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Release the library
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/k8s.cni.cncf.io_ipamleases.yaml


### PR DESCRIPTION
Whenever the a tag is pushed to the repo, a new github release is generated:

```
git tag vx.y.z[-alpha|beta]
git push <remote> --tags
```