### PR TITLE
crd, Status.IPs: Add omitempty, MinItems attributes

### DIFF
--- a/artifacts/k8s.cni.cncf.io_ipamclaims.yaml
+++ b/artifacts/k8s.cni.cncf.io_ipamclaims.yaml
@@ -116,6 +116,7 @@ spec:
                   for the pod interface
                 items:
                   type: string
+                minItems: 1
                 type: array
               ownerPod:
                 description: The name of the pod holding the IPAMClaim
@@ -123,8 +124,6 @@ spec:
                   name:
                     type: string
                 type: object
-            required:
-            - ips
             type: object
         type: object
     served: true

--- a/pkg/crd/ipamclaims/v1alpha1/types.go
+++ b/pkg/crd/ipamclaims/v1alpha1/types.go
@@ -38,7 +38,8 @@ type IPAMClaimSpec struct {
 // IPAMClaimStatus contains the observed status of the IPAMClaim.
 type IPAMClaimStatus struct {
 	// The list of IP addresses (v4, v6) that were allocated for the pod interface
-	IPs []string `json:"ips"`
+	// +kubebuilder:validation:MinItems=1
+	IPs []string `json:"ips,omitempty"`
 	// The name of the pod holding the IPAMClaim
 	OwnerPod *OwnerPod `json:"ownerPod,omitempty"`
 	// Conditions contains details for one aspect of the current state of this API Resource


### PR DESCRIPTION
This PR is setting the omitempty and  MinItems=1 to the IPs field.

Reason: it is essintial to be able to set status attributes (such as conditions) even if the IPs field is empty. 
This requires making the attribute `omitempty`.
Setting the MinItems=1 is meant to avoid setting an empty slice which is confusing according to the API team.

