### PR TITLE
status: add DelegatedPrefixes for DHCPv6 prefix-delegation persistence

### DIFF
--- a/artifacts/k8s.cni.cncf.io_ipamclaims.yaml
+++ b/artifacts/k8s.cni.cncf.io_ipamclaims.yaml
@@ -111,6 +111,14 @@ spec:
                   - type
                   type: object
                 type: array
+              delegatedPrefixes:
+                description: |-
+                  The list of IPv6 prefixes (CIDR) delegated to the pod interface via DHCPv6
+                  Prefix Delegation, persisted so the same prefix is reproduced across pod
+                  churn (e.g. KubeVirt live migration)
+                items:
+                  type: string
+                type: array
               ips:
                 description: The list of IP addresses (v4, v6) that were allocated
                   for the pod interface

--- a/pkg/crd/ipamclaims/v1alpha1/types.go
+++ b/pkg/crd/ipamclaims/v1alpha1/types.go
@@ -39,6 +39,10 @@ type IPAMClaimSpec struct {
 type IPAMClaimStatus struct {
 	// The list of IP addresses (v4, v6) that were allocated for the pod interface
 	IPs []string `json:"ips"`
+	// The list of IPv6 prefixes (CIDR) delegated to the pod interface via DHCPv6
+	// Prefix Delegation, persisted so the same prefix is reproduced across pod
+	// churn (e.g. KubeVirt live migration)
+	DelegatedPrefixes []string `json:"delegatedPrefixes,omitempty"`
 	// The name of the pod holding the IPAMClaim
 	OwnerPod *OwnerPod `json:"ownerPod,omitempty"`
 	// Conditions contains details for one aspect of the current state of this API Resource

--- a/pkg/crd/ipamclaims/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/crd/ipamclaims/v1alpha1/zz_generated.deepcopy.go
@@ -91,6 +91,11 @@ func (in *IPAMClaimStatus) DeepCopyInto(out *IPAMClaimStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DelegatedPrefixes != nil {
+		in, out := &in.DelegatedPrefixes, &out.DelegatedPrefixes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.OwnerPod != nil {
 		in, out := &in.OwnerPod, &out.OwnerPod
 		*out = new(OwnerPod)


### PR DESCRIPTION
### What
Add an optional `Status.DelegatedPrefixes []string` field to the `IPAMClaim` CRD,
holding the IPv6 prefix(es) (CIDR) delegated to a pod interface via DHCPv6 Prefix
Delegation.

```go
// The list of IPv6 prefixes (CIDR) delegated to the pod interface via DHCPv6
// Prefix Delegation, persisted so the same prefix is reproduced across pod
// churn (e.g. KubeVirt live migration)
DelegatedPrefixes []string `json:"delegatedPrefixes,omitempty"`
```

### Why
`IPAMClaim.Status` already persists the interface's IA_NA addresses in `IPs` so an
IPAM consumer can reproduce them on a new pod for the same workload (the KubeVirt
live-migration case). DHCPv6 Prefix Delegation gives a workload an additional,
separately-allocated **routed IPv6 prefix**. That prefix has the same 1:1 lifecycle
as the interface address and the same migration-stability requirement: the consumer
must hand the migration-target pod the *same* prefix, or a guest holding the prefix on
an infinite DHCPv6 lease is stranded. No field persists it today.

The first consumer is OVN-Kubernetes' DHCPv6-PD feature (OKEP "Migration-stable DHCPv6
Prefix Delegation"), which allocates the prefix, persists it here, and re-asserts the
route and DHCP option on the migration target from this field.

### Compatibility
- Additive and optional (`omitempty`). Existing producers/consumers are unaffected; a
  cluster running the old CRD never sets the field. No API break, no conversion.

### Generated artifacts
Regenerated alongside the type change and included in this commit:
- `artifacts/k8s.cni.cncf.io_ipamclaims.yaml` (CRD)
- `pkg/crd/ipamclaims/v1alpha1/zz_generated.deepcopy.go`

(Re-run `make generate` before pushing if your toolchain version differs, to confirm a
clean diff.)

---

### Reviewer note (mirrors the existing `IPs` field)
The field intentionally parallels `Status.IPs` in shape (a `[]string` of CIDRs) and in
its comment, so the persistence semantics are obvious by analogy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new status field to retain delegated IPv6 prefix information for IPAM claims.
  * This helps preserve prefix details across pod restarts or migration events.

* **Bug Fixes**
  * Improved persistence of prefix data so it is correctly stored and restored when objects are duplicated or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->